### PR TITLE
feat: implement client registration caching for AWS SSO OIDC

### DIFF
--- a/internal/sso/cache.go
+++ b/internal/sso/cache.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,11 +28,10 @@ type ClientRegistrationCache struct {
 	ReceivedAt   time.Time `json:"receivedAt"`
 }
 
-// normalizeStartURL removes a trailing "#" or "/" from startURL to normalize AWS SSO start URLs.
+// normalizeStartURL removes trailing "#" and "/" characters from startURL to normalize AWS SSO start URLs.
+// Handles edge cases like "/#", "/#/", etc.
 func normalizeStartURL(startURL string) string {
-	startURL = strings.TrimSuffix(startURL, "#")
-	startURL = strings.TrimSuffix(startURL, "/")
-	return startURL
+	return strings.TrimRight(startURL, "#/")
 }
 
 // getTokenCachePath returns the filesystem path for the SSO token cache file corresponding to startURL.
@@ -75,7 +75,9 @@ func LoadTokenCache(startURL string) (*TokenCache, error) {
 	data, err := os.ReadFile(path)
 	if err == nil {
 		var token TokenCache
-		if err := json.Unmarshal(data, &token); err == nil {
+		if err := json.Unmarshal(data, &token); err != nil {
+			log.Printf("⚠️ Warning: Failed to parse token cache %s (possible corruption): %v", path, err)
+		} else {
 			return &token, nil
 		}
 	}

--- a/internal/sso/cache.go
+++ b/internal/sso/cache.go
@@ -201,7 +201,10 @@ func ClearTokenCache() error {
 	return nil
 }
 
-// user home directory cannot be determined or the cache directory cannot be created.
+// getClientRegistrationCachePath returns the filesystem path for the botocore-style
+// client registration cache file for the given region. It ensures the ~/.aws/sso/cache
+// directory exists. An error is returned if the user home directory cannot be determined
+// or the cache directory cannot be created.
 func getClientRegistrationCachePath(region string) (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/sso/cache.go
+++ b/internal/sso/cache.go
@@ -161,11 +161,17 @@ func ClearTokenCache() error {
 	}
 
 	for _, entry := range entries {
-		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".json" {
-			cachePath := filepath.Join(cacheDir, entry.Name())
-			if err := os.Remove(cachePath); err != nil {
-				return err
-			}
+		// Skip directories and non-JSON files
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		// Preserve client registration files (valid for 90 days)
+		if strings.HasPrefix(entry.Name(), "botocore-client-id-") {
+			continue
+		}
+		cachePath := filepath.Join(cacheDir, entry.Name())
+		if err := os.Remove(cachePath); err != nil {
+			return err
 		}
 	}
 

--- a/internal/sso/cache.go
+++ b/internal/sso/cache.go
@@ -27,13 +27,17 @@ type ClientRegistrationCache struct {
 	ReceivedAt   time.Time `json:"receivedAt"`
 }
 
-// normalizeStartURL removes trailing /# or / to match aws-sso-util format
+// normalizeStartURL removes a trailing "#" or "/" from startURL to normalize AWS SSO start URLs.
 func normalizeStartURL(startURL string) string {
 	startURL = strings.TrimSuffix(startURL, "#")
 	startURL = strings.TrimSuffix(startURL, "/")
 	return startURL
 }
 
+// getTokenCachePath returns the filesystem path for the SSO token cache file corresponding to startURL.
+// It ensures the ~/.aws/sso/cache directory exists, normalizes startURL (removes trailing "#" and "/"),
+// and uses the SHA-1 hex of the normalized URL with a ".json" extension as the filename.
+// An error is returned if the user's home directory cannot be determined or the cache directory cannot be created.
 func getTokenCachePath(startURL string) (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -52,6 +56,15 @@ func getTokenCachePath(startURL string) (string, error) {
 	return filepath.Join(cacheDir, hash+".json"), nil
 }
 
+// LoadTokenCache loads the SSO token cache for the given start URL.
+// It first attempts a direct lookup using the normalized start URL hash, and if that
+// fails it scans the SSO cache directory for a token whose stored StartUrl matches
+// the provided start URL (after normalization).
+//
+// The startURL parameter is the SSO start URL used to locate the cached token.
+// It returns a pointer to the TokenCache when a matching cache file is found,
+// (nil, nil) if no matching token exists, or (nil, error) if an I/O or parsing
+// error occurs.
 func LoadTokenCache(startURL string) (*TokenCache, error) {
 	// First try direct path lookup with normalized URL
 	path, err := getTokenCachePath(startURL)
@@ -72,7 +85,10 @@ func LoadTokenCache(startURL string) (*TokenCache, error) {
 	return findTokenByStartURL(startURL)
 }
 
-// findTokenByStartURL scans all cache files to find a token matching the startURL
+// findTokenByStartURL scans the user's SSO cache (~/.aws/sso/cache) for a token whose StartUrl matches the provided startURL after normalization.
+// It ignores directories, non-`.json` files, and files prefixed with "botocore-client-id-"; unreadable or unparseable files are skipped.
+// If a matching token is found it is returned. If no match is found or the cache directory does not exist, (nil, nil) is returned.
+// Any error encountered while reading the cache directory is returned.
 func findTokenByStartURL(startURL string) (*TokenCache, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -119,6 +135,9 @@ func findTokenByStartURL(startURL string) (*TokenCache, error) {
 	return nil, nil
 }
 
+// SaveTokenCache writes a botocore-compatible SSO token cache file for the given start URL and region.
+// It serializes a TokenCache containing the normalized StartUrl, Region, AccessToken, ExpiresAt, and the current ReceivedAt timestamp, and writes it to the per-start-URL cache file with file mode 0600.
+// Returns an error if the cache path cannot be determined, JSON marshaling fails, or the file cannot be written.
 func SaveTokenCache(accessToken, startUrl, region string, expiresAt time.Time) error {
 	path, err := getTokenCachePath(startUrl)
 	if err != nil {
@@ -141,6 +160,10 @@ func SaveTokenCache(accessToken, startUrl, region string, expiresAt time.Time) e
 	return os.WriteFile(path, data, 0600)
 }
 
+// ClearTokenCache removes all SSO token cache JSON files from the user's
+// ~/.aws/sso/cache directory except for botocore client-registration files.
+// It returns nil if the cache directory does not exist and otherwise
+// propagates any filesystem errors encountered while reading or removing files.
 func ClearTokenCache() error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -178,6 +201,7 @@ func ClearTokenCache() error {
 	return nil
 }
 
+// user home directory cannot be determined or the cache directory cannot be created.
 func getClientRegistrationCachePath(region string) (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -194,6 +218,8 @@ func getClientRegistrationCachePath(region string) (string, error) {
 	return filepath.Join(cacheDir, filename), nil
 }
 
+// LoadClientRegistration reads the botocore-style client registration cache for the given region.
+// It returns the cached ClientRegistrationCache if present, `nil, nil` when no cache file exists, or an error if reading or JSON unmarshalling fails.
 func LoadClientRegistration(region string) (*ClientRegistrationCache, error) {
 	path, err := getClientRegistrationCachePath(region)
 	if err != nil {
@@ -216,6 +242,8 @@ func LoadClientRegistration(region string) (*ClientRegistrationCache, error) {
 	return &cache, nil
 }
 
+// SaveClientRegistration writes botocore-compatible client registration data for the given region into the SSO cache directory.
+// The stored record contains the client ID, client secret, the provided expiration time, and the current receipt timestamp; an error is returned if the cache path cannot be determined or the file cannot be written.
 func SaveClientRegistration(region, clientId, clientSecret string, expiresAt time.Time) error {
 	path, err := getClientRegistrationCachePath(region)
 	if err != nil {

--- a/internal/sso/cache.go
+++ b/internal/sso/cache.go
@@ -6,17 +6,32 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
+// TokenCache is botocore-compatible format used by aws-sso-util and assume/granted
 type TokenCache struct {
-	AccessToken  string    `json:"accessToken"`
-	ExpiresAt    time.Time `json:"expiresAt"`
-	RefreshToken string    `json:"refreshToken"`
+	StartUrl    string    `json:"startUrl"`
+	Region      string    `json:"region"`
+	AccessToken string    `json:"accessToken"`
+	ExpiresAt   time.Time `json:"expiresAt"`
+	ReceivedAt  time.Time `json:"receivedAt"`
+}
+
+// ClientRegistrationCache stores client registration data in botocore-compatible format
+type ClientRegistrationCache struct {
 	ClientId     string    `json:"clientId"`
 	ClientSecret string    `json:"clientSecret"`
-	StartUrl     string    `json:"startUrl"`
-	Region       string    `json:"region"`
+	ExpiresAt    time.Time `json:"expiresAt"`
+	ReceivedAt   time.Time `json:"receivedAt"`
+}
+
+// normalizeStartURL removes trailing /# or / to match aws-sso-util format
+func normalizeStartURL(startURL string) string {
+	startURL = strings.TrimSuffix(startURL, "#")
+	startURL = strings.TrimSuffix(startURL, "/")
+	return startURL
 }
 
 func getTokenCachePath(startURL string) (string, error) {
@@ -31,18 +46,41 @@ func getTokenCachePath(startURL string) (string, error) {
 		return "", err
 	}
 
-	// Generate hash of start URL for filename
-	hash := fmt.Sprintf("%x", sha1.Sum([]byte(startURL)))
+	// Normalize URL to match aws-sso-util format
+	normalizedURL := normalizeStartURL(startURL)
+	hash := fmt.Sprintf("%x", sha1.Sum([]byte(normalizedURL)))
 	return filepath.Join(cacheDir, hash+".json"), nil
 }
 
 func LoadTokenCache(startURL string) (*TokenCache, error) {
+	// First try direct path lookup with normalized URL
 	path, err := getTokenCachePath(startURL)
 	if err != nil {
 		return nil, err
 	}
 
 	data, err := os.ReadFile(path)
+	if err == nil {
+		var token TokenCache
+		if err := json.Unmarshal(data, &token); err == nil {
+			return &token, nil
+		}
+	}
+
+	// If direct lookup fails, scan cache files for matching startUrl
+	// This handles tokens created by other tools with different URL formats
+	return findTokenByStartURL(startURL)
+}
+
+// findTokenByStartURL scans all cache files to find a token matching the startURL
+func findTokenByStartURL(startURL string) (*TokenCache, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	cacheDir := filepath.Join(homeDir, ".aws", "sso", "cache")
+	entries, err := os.ReadDir(cacheDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -50,21 +88,52 @@ func LoadTokenCache(startURL string) (*TokenCache, error) {
 		return nil, err
 	}
 
-	var token TokenCache
-	if err := json.Unmarshal(data, &token); err != nil {
-		return nil, err
+	normalizedTarget := normalizeStartURL(startURL)
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		// Skip botocore client registration files
+		if strings.HasPrefix(entry.Name(), "botocore-client-id-") {
+			continue
+		}
+
+		filePath := filepath.Join(cacheDir, entry.Name())
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			continue
+		}
+
+		var token TokenCache
+		if err := json.Unmarshal(data, &token); err != nil {
+			continue
+		}
+
+		// Check if this token's startUrl matches (after normalization)
+		if token.StartUrl != "" && normalizeStartURL(token.StartUrl) == normalizedTarget {
+			return &token, nil
+		}
 	}
 
-	return &token, nil
+	return nil, nil
 }
 
-func SaveTokenCache(token *TokenCache) error {
-	path, err := getTokenCachePath(token.StartUrl)
+func SaveTokenCache(accessToken, startUrl, region string, expiresAt time.Time) error {
+	path, err := getTokenCachePath(startUrl)
 	if err != nil {
 		return err
 	}
 
-	data, err := json.Marshal(token)
+	cache := TokenCache{
+		StartUrl:    normalizeStartURL(startUrl),
+		Region:      region,
+		AccessToken: accessToken,
+		ExpiresAt:   expiresAt,
+		ReceivedAt:  time.Now(),
+	}
+
+	data, err := json.Marshal(cache)
 	if err != nil {
 		return err
 	}
@@ -101,4 +170,63 @@ func ClearTokenCache() error {
 	}
 
 	return nil
+}
+
+func getClientRegistrationCachePath(region string) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	cacheDir := filepath.Join(homeDir, ".aws", "sso", "cache")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		return "", err
+	}
+
+	// Use botocore-compatible filename
+	filename := fmt.Sprintf("botocore-client-id-%s.json", region)
+	return filepath.Join(cacheDir, filename), nil
+}
+
+func LoadClientRegistration(region string) (*ClientRegistrationCache, error) {
+	path, err := getClientRegistrationCachePath(region)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var cache ClientRegistrationCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil, err
+	}
+
+	return &cache, nil
+}
+
+func SaveClientRegistration(region, clientId, clientSecret string, expiresAt time.Time) error {
+	path, err := getClientRegistrationCachePath(region)
+	if err != nil {
+		return err
+	}
+
+	cache := ClientRegistrationCache{
+		ClientId:     clientId,
+		ClientSecret: clientSecret,
+		ExpiresAt:    expiresAt,
+		ReceivedAt:   time.Now(),
+	}
+
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0600)
 }

--- a/internal/sso/client.go
+++ b/internal/sso/client.go
@@ -41,20 +41,42 @@ func (c *Client) Authenticate(ctx context.Context) (*ssooidc.CreateTokenOutput, 
 		}, nil
 	}
 
-	// Step 1: Begin device authorization
+	// Step 1: Get or register client
 	ssoOidc := ssooidc.NewFromConfig(aws.Config{Region: c.region})
 
-	register, err := ssoOidc.RegisterClient(ctx, &ssooidc.RegisterClientInput{
-		ClientName: aws.String("bifrost"),
-		ClientType: aws.String("public"),
-	})
+	var clientId, clientSecret string
+
+	// Try to load cached client registration
+	cachedReg, err := LoadClientRegistration(c.region)
 	if err != nil {
-		return nil, fmt.Errorf("RegisterClient: %w", err)
+		log.Printf("⚠️ Warning: Failed to load cached client registration: %v", err)
+	}
+
+	if cachedReg != nil && time.Now().Before(cachedReg.ExpiresAt) {
+		clientId = cachedReg.ClientId
+		clientSecret = cachedReg.ClientSecret
+	} else {
+		// Register new client
+		register, err := ssoOidc.RegisterClient(ctx, &ssooidc.RegisterClientInput{
+			ClientName: aws.String("bifrost"),
+			ClientType: aws.String("public"),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("RegisterClient: %w", err)
+		}
+		clientId = *register.ClientId
+		clientSecret = *register.ClientSecret
+
+		// Cache the client registration using AWS-provided expiration
+		expiresAt := time.Unix(register.ClientSecretExpiresAt, 0)
+		if err := SaveClientRegistration(c.region, clientId, clientSecret, expiresAt); err != nil {
+			log.Printf("⚠️ Warning: Failed to cache client registration: %v", err)
+		}
 	}
 
 	deviceAuth, err := ssoOidc.StartDeviceAuthorization(ctx, &ssooidc.StartDeviceAuthorizationInput{
-		ClientId:     register.ClientId,
-		ClientSecret: register.ClientSecret,
+		ClientId:     aws.String(clientId),
+		ClientSecret: aws.String(clientSecret),
 		StartUrl:     aws.String(c.startURL),
 	})
 	if err != nil {
@@ -95,8 +117,8 @@ func (c *Client) Authenticate(ctx context.Context) (*ssooidc.CreateTokenOutput, 
 
 		time.Sleep(time.Duration(deviceAuth.Interval) * time.Second)
 		token, err = ssoOidc.CreateToken(ctx, &ssooidc.CreateTokenInput{
-			ClientId:     register.ClientId,
-			ClientSecret: register.ClientSecret,
+			ClientId:     aws.String(clientId),
+			ClientSecret: aws.String(clientSecret),
 			DeviceCode:   deviceAuth.DeviceCode,
 			GrantType:    aws.String("urn:ietf:params:oauth:grant-type:device_code"),
 		})
@@ -110,16 +132,8 @@ func (c *Client) Authenticate(ctx context.Context) (*ssooidc.CreateTokenOutput, 
 		}
 	}
 
-	// Cache the new token
-	cacheToken := &TokenCache{
-		AccessToken:  *token.AccessToken,
-		ExpiresAt:    time.Now().Add(8 * time.Hour), // SSO tokens typically expire in 8 hours
-		ClientId:     *register.ClientId,
-		ClientSecret: *register.ClientSecret,
-		StartUrl:     c.startURL,
-		Region:       c.region,
-	}
-	if err := SaveTokenCache(cacheToken); err != nil {
+	// Cache the new token in botocore-compatible format
+	if err := SaveTokenCache(*token.AccessToken, c.startURL, c.region, time.Now().Add(8*time.Hour)); err != nil {
 		log.Printf("⚠️ Warning: Failed to cache token: %v", err)
 	}
 

--- a/internal/sso/client.go
+++ b/internal/sso/client.go
@@ -133,7 +133,9 @@ func (c *Client) Authenticate(ctx context.Context) (*ssooidc.CreateTokenOutput, 
 	}
 
 	// Cache the new token in botocore-compatible format
-	if err := SaveTokenCache(*token.AccessToken, c.startURL, c.region, time.Now().Add(8*time.Hour)); err != nil {
+	// Use ExpiresIn from AWS response (seconds until expiration)
+	expiresAt := time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
+	if err := SaveTokenCache(*token.AccessToken, c.startURL, c.region, expiresAt); err != nil {
 		log.Printf("⚠️ Warning: Failed to cache token: %v", err)
 	}
 

--- a/internal/sso/client.go
+++ b/internal/sso/client.go
@@ -64,8 +64,8 @@ func (c *Client) Authenticate(ctx context.Context) (*ssooidc.CreateTokenOutput, 
 		if err != nil {
 			return nil, fmt.Errorf("RegisterClient: %w", err)
 		}
-		clientId = *register.ClientId
-		clientSecret = *register.ClientSecret
+		clientId = aws.ToString(register.ClientId)
+		clientSecret = aws.ToString(register.ClientSecret)
 
 		// Cache the client registration using AWS-provided expiration
 		expiresAt := time.Unix(register.ClientSecretExpiresAt, 0)


### PR DESCRIPTION
This PR implements client registration caching to reduce AWS SSO OIDC API calls and improve compatibility with aws-sso-util and granted/assume tools.

Key improvements: Client registrations are cached for 90 days in botocore-compatible format, token cache format matches aws-sso-util exactly, URL normalization ensures compatibility across tools, and smart token lookup scans all cache files for cross-tool compatibility.

The caching mechanism stores client registrations in `~/.aws/sso/cache/botocore-client-id-{region}.json` and tokens remain compatible with other AWS tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load-or-reuse client registration to avoid repeated registrations during device authorization.
  * Token and client registration caches now record receipt timestamps and include normalized start-URL and region metadata for consistent matching.

* **Bug Fixes**
  * Improved token lookup with direct-path then directory-scan fallback for reliable retrieval.
  * Safer cache file/dir handling to avoid accidental removals and preserve unrelated client-id files.

* **Chores**
  * Added clarifying in-code documentation for cache behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->